### PR TITLE
team points

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,7 @@
 class TeamsController < ApplicationController
   def show
     @team = Team.find(params[:id])
+    spots = @team.spots
+    participations = Participation.where(spot: spots)
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,8 +1,21 @@
 class TeamsController < ApplicationController
   def show
-    @team = Team.find(params[:id])
-    spots = @team.spots
-    participations = Participation.where(spot: spots)
-    @total_points = participations.map { |p| p.action_type.points }.sum
+    @team = current_user.team
+    @my_team_total_points = calculate_total_points(Participation.where(spot: @team.spots))
+
+    all_teams_participations = Participation.joins(:spot).where(spots: { team: Team.all })
+    @total_points_by_team = calculate_total_points_by_team(all_teams_participations)
+  end
+
+  private
+
+  def calculate_total_points(participations)
+    participations.map { |p| p.action_type.points }.sum
+  end
+
+  def calculate_total_points_by_team(participations)
+    participations.group_by { |p| p.spot.team }.transform_values do |team_participations|
+      calculate_total_points(team_participations)
+    end
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -5,7 +5,7 @@ class TeamsController < ApplicationController
 
     all_teams_participations = Participation.joins(:spot).where(spots: { team: Team.all })
     # An array of hashes with an instance of Team as key and the total points of that team as value
-    @total_points_by_team = calculate_total_points_by_team(all_teams_participations)
+    @total_points_by_team = calculate_total_points_by_team(all_teams_participations).sort_by { |_team, points| points }.reverse.to_h
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -3,7 +3,6 @@ class TeamsController < ApplicationController
     @team = Team.find(params[:id])
     spots = @team.spots
     participations = Participation.where(spot: spots)
-    points = participations.map { |p| p.action_type.points }.sum
-    raise
+    @total_points = participations.map { |p| p.action_type.points }.sum
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,6 +4,7 @@ class TeamsController < ApplicationController
     @my_team_total_points = calculate_total_points(Participation.where(spot: @team.spots))
 
     all_teams_participations = Participation.joins(:spot).where(spots: { team: Team.all })
+    # An array of hashes with an instance of Team as key and the total points of that team as value
     @total_points_by_team = calculate_total_points_by_team(all_teams_participations)
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -3,5 +3,7 @@ class TeamsController < ApplicationController
     @team = Team.find(params[:id])
     spots = @team.spots
     participations = Participation.where(spot: spots)
+    points = participations.map { |p| p.action_type.points }.sum
+    raise
   end
 end

--- a/app/models/action_type.rb
+++ b/app/models/action_type.rb
@@ -1,2 +1,3 @@
 class ActionType < ApplicationRecord
+  has_many :participations
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,5 +1,5 @@
 class Participation < ApplicationRecord
-  has_one :action_type
+  belongs_to :action_type
   belongs_to :user
   belongs_to :event, optional: true
   belongs_to :spot

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,5 +1,5 @@
 class Participation < ApplicationRecord
-  belongs_to :action_type
+  has_one :action_type
   belongs_to :user
   belongs_to :event, optional: true
   belongs_to :spot

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -3,5 +3,6 @@ class Participation < ApplicationRecord
   belongs_to :user
   belongs_to :event, optional: true
   belongs_to :spot
+  belongs_to :team
   has_one_attached :photo
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,5 @@
 class Team < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :spots, dependent: :destroy
+  has_many :participations, through: :spots
 end

--- a/app/views/teams/_team_ranking.html.erb
+++ b/app/views/teams/_team_ranking.html.erb
@@ -2,8 +2,8 @@
     <% teams.each do |team| %>
       <li class="d-flex justify-content-between align-items-center">
         <p class="<%= team[0] == current_user.team ? "fw-bold" : ""%>"><%= team[0].name %></p>
-        <div class="d-flex justify-content-between">
-          <p><%= team[1] %></p>
+        <div class="d-flex justify-content-between gap-2">
+          <p><%= team[1] %>pts</p>
           <p><%= "🔺🔻" %></p> <%# TODO: add logic for arrows %>
         </div>
       </li>

--- a/app/views/teams/_team_ranking.html.erb
+++ b/app/views/teams/_team_ranking.html.erb
@@ -1,15 +1,11 @@
   <ul class="list-group m-3">
-    <% @teams.each do |team| %>
+    <% teams.each do |team| %>
       <li class="d-flex justify-content-between align-items-center">
-      <div class="d-flex">
-        <p><%= team.id %> - </p>
-        <p><%= team.name %></p>
-      </div>
-      <div class="d-flex">
-      <%# ##ici la fonction implementée par la logique de calcul (idem dans controller) + progression des équipes grace au fleches %>
-      <p><%= "1000pts" %></p>
-      <p><%= "🔺🔻" %></p>
-      </div>
+        <p class="<%= team[0] == current_user.team ? "fw-bold" : ""%>"><%= team[0].name %></p>
+        <div class="d-flex justify-content-between">
+          <p><%= team[1] %></p>
+          <p><%= "🔺🔻" %></p> <%# TODO: add logic for arrows %>
+        </div>
       </li>
     <% end %>
   </ul>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -27,7 +27,7 @@
       <div class="p-3 mt-4">
         <div id="ranking-chart">
           <h5>Classement</h5>
-            <%= render "team_ranking", team: @teams %>
+            <%= render "team_ranking", teams: @total_points_by_team %>
         </div>
       </div>
     </div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -4,10 +4,10 @@
   <div class="row">
     <div class="col-12 text-center mt-4">
       <h4>Général</h4>
-        <div class= "d-flex justify-content-center align-item-baseline">
-          <%= image_tag 'user_marker.png', height: 60, width: 60, alt: "user marker" %>
-          <h6 class="my-3"> '1500pts   +30pts'</h6>
-        </div>
+      <div class= "d-flex justify-content-center align-item-baseline gap-2">
+        <%= image_tag 'user_marker.png', height: 60, width: 60, alt: "user marker" %>
+        <h6 class="my-3"><%= @my_team_total_points %>pts | 🔺30pts</h6>
+      </div>
     </div>
   </div>
   <p class="my-3 text-center">**********************************************</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,7 @@ puts "Creating actions..."
 action1 = ActionType.create!(name: "water spot", points: 10)
 action2 = ActionType.create!(name: "care", points: 10)
 action3 = ActionType.create!(name: "plant", points: 20)
-action4 = ActionType.create!(name: "denounce", points: -5)
+action4 = ActionType.create!(name: "denounce", points: -10)
 
 p actions = [action1, action2, action3, action4]
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,7 @@ puts "Creating actions..."
 action1 = ActionType.create!(name: "water spot", points: 10)
 action2 = ActionType.create!(name: "care", points: 10)
 action3 = ActionType.create!(name: "plant", points: 20)
-action4 = ActionType.create!(name: "denounce", points: 5)
+action4 = ActionType.create!(name: "denounce", points: -5)
 
 p actions = [action1, action2, action3, action4]
 
@@ -53,7 +53,8 @@ document = File.read(filepath)
 response = JSON.parse(document)
 spots_data = response["features"]
 
-spots_data.each do |spot_data|
+spots = Rails.env == "development" ? spots_data.first(10) : spots_data
+spots.each do |spot_data|
   random_team = teams.sample.id
   p Spot.create!(
     name: spot_data["properties"]["Name"],


### PR DESCRIPTION
Calculates points for all teams and current team.

Exposes said points to Team show. 
At the moment leaderboard has no logic for increase decrease in points this is a TODO for later. 

Updates seeds to have negative points when needed (and a handy trick for seeding fewer spots **only** in dev environment.