### PR TITLE
custom map markers

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -2,13 +2,7 @@ class SpotsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
-    @markers = Spot.geocoded.map do |spot|
-      {
-        lat: spot.latitude,
-        lng: spot.longitude,
-        spot: { id: spot.id, name: spot.name, address: spot.address }
-      }
-    end
+    @markers = spot_hash
     @user_marker = render_to_string(partial: "spots/user_marker")
   end
 
@@ -17,6 +11,33 @@ class SpotsController < ApplicationController
     @last_participations = @spot.participations.sort_by(&:created_at).first(2)
     respond_to do |format|
       format.text { render(partial: "spots/spot_details", locals: { spot: @spot }, formats: [:html]) }
+    end
+  end
+
+  private
+
+  def spot_hash
+    Spot.geocoded.map do |spot|
+      {
+        lat: spot.latitude,
+        lng: spot.longitude,
+        id: spot.id,
+        name: spot.name,
+        address: spot.address,
+        marker_html: render_to_string(partial: "shared/marker", locals: { img: spot_marker(spot) })
+      }
+    end
+  end
+
+  def spot_marker(spot)
+    if spot.is_open?
+      if spot.is_dry?
+        'plant_dying.png'
+      else
+        'plant.png'
+      end
+    else
+      'raid.png'
     end
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,4 +1,5 @@
 class SpotsController < ApplicationController
+  include ActionIntervals
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
@@ -31,7 +32,7 @@ class SpotsController < ApplicationController
 
   def spot_marker(spot)
     if spot.is_open?
-      if spot.is_dry?
+      if plant_dry?(spot)
         'plant_dying.png'
       else
         'plant.png'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,16 +6,10 @@ module ApplicationHelper
   end
 
   def participation_history(participation)
-    case participation.action_type.name
-    when "water spot"
-      return "#{participation.user.username} a arrosé  #{time_difference_in_days(participation.created_at)}"
-    when "care"
-      return "#{participation.user.username} a désherbé #{time_difference_in_days(participation.created_at)}"
-    when "plant"
-      "#{participation.user.username} a planté #{time_difference_in_days(participation.created_at)}"
-    when "denounce"
-      return "#{participation.user.team.name} vous a trash #{time_difference_in_days(participation.created_at)}!"
-    end
+    action_mapping = { "water spot" => "arrosé", "care" => "désherbé", "plant" => "planté", "denounce" => "trash" }
+    action_name = action_mapping[participation&.action_type&.name]
+    user_or_team_name = participation&.action_type&.name == "denounce" ? participation.user.team.name : participation.user.username
+    "#{user_or_team_name} a #{action_name} #{time_difference_in_days(participation&.created_at)}" if action_name
   end
 
   def time_difference_in_days(from_time, to_time = Time.now)

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -137,13 +137,15 @@ export default class extends Controller {
 
   #addMarkersToMap() {
     this.markersValue.forEach((marker) => {
-      const newMarker = new mapboxgl.Marker()
+      const customMarker = document.createElement("div")
+    customMarker.innerHTML = marker.marker_html
+      const newMarker = new mapboxgl.Marker(customMarker)
         .setLngLat([ marker.lng, marker.lat ])
         .addTo(this.map)
 
       const markerHtml = newMarker.getElement()
       markerHtml.setAttribute('data-action', 'click->map#showSpotDetails')
-      markerHtml.setAttribute(`data-id`, marker.spot.id)
+      markerHtml.setAttribute(`data-id`, marker.id)
     })
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -138,7 +138,7 @@ export default class extends Controller {
   #addMarkersToMap() {
     this.markersValue.forEach((marker) => {
       const customMarker = document.createElement("div")
-    customMarker.innerHTML = marker.marker_html
+      customMarker.innerHTML = marker.marker_html
       const newMarker = new mapboxgl.Marker(customMarker)
         .setLngLat([ marker.lng, marker.lat ])
         .addTo(this.map)

--- a/app/views/shared/_marker.html.erb
+++ b/app/views/shared/_marker.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag img, height: 40, width: 40 %>

--- a/db/migrate/20231205104021_remove_is_dry_from_spots.rb
+++ b/db/migrate/20231205104021_remove_is_dry_from_spots.rb
@@ -1,0 +1,4 @@
+class RemoveIsDryFromSpots < ActiveRecord::Migration[7.1]
+  def change
+  end
+end

--- a/db/migrate/20231205104021_remove_is_dry_from_spots.rb
+++ b/db/migrate/20231205104021_remove_is_dry_from_spots.rb
@@ -1,4 +1,5 @@
 class RemoveIsDryFromSpots < ActiveRecord::Migration[7.1]
   def change
+    remove_column :spots, :is_dry, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,7 +100,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_05_104021) do
     t.datetime "updated_at", null: false
     t.bigint "team_id", null: false
     t.boolean "is_open", default: true, null: false
-    t.boolean "is_dry"
     t.index ["team_id"], name: "index_spots_on_team_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_04_131629) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_05_104021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -100,7 +100,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_04_131629) do
     t.datetime "updated_at", null: false
     t.bigint "team_id", null: false
     t.boolean "is_open", default: true, null: false
-    t.boolean "is_dry", default: false, null: false
+    t.boolean "is_dry"
     t.index ["team_id"], name: "index_spots_on_team_id"
   end
 

--- a/lib/action_intervals.rb
+++ b/lib/action_intervals.rb
@@ -5,4 +5,12 @@ module ActionIntervals
     "plant" => 89.days,
     "denounce" => 1.day
   }.freeze
+
+  def plant_dry?(spot)
+    action = ActionType.find_by(name: "water spot")
+    return true unless spot.participations.where(action_type: action).any?
+
+    last_watering = spot.participations.where(action_type: action).last&.created_at
+    last_watering < Time.now - (INTERVALS_MAPPING["water spot"] * 2)
+  end
 end


### PR DESCRIPTION
Adds logic to determine if plant is dry or not. This removes the need to have a `is_dry` field in the spot model.

Picks a marker based on the plant status. 

Updates `participation_history` to account for no `action_type`.